### PR TITLE
[#26] Ranking 스케줄러 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,8 @@ dependencies {
 
     // TestContainer
     testImplementation 'org.testcontainers:junit-jupiter:1.17.3'
+    // mongodb
+    implementation ('org.springframework.boot:spring-boot-starter-data-mongodb')
 }
 
 tasks.named('test') {

--- a/src/main/java/com/kurkus/kusinsa/KusinsaApplication.java
+++ b/src/main/java/com/kurkus/kusinsa/KusinsaApplication.java
@@ -4,12 +4,14 @@ import javax.persistence.EntityListeners;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.EnableAspectJAutoProxy;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.session.data.redis.config.annotation.web.http.EnableRedisHttpSession;
 
+@EnableCaching
 @EnableScheduling
 @EnableAspectJAutoProxy
 @EnableJpaAuditing

--- a/src/main/java/com/kurkus/kusinsa/KusinsaApplication.java
+++ b/src/main/java/com/kurkus/kusinsa/KusinsaApplication.java
@@ -10,7 +10,7 @@ import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.session.data.redis.config.annotation.web.http.EnableRedisHttpSession;
 
-
+@EnableScheduling
 @EnableAspectJAutoProxy
 @EnableJpaAuditing
 @SpringBootApplication

--- a/src/main/java/com/kurkus/kusinsa/config/redis/RedisCacheConfig.java
+++ b/src/main/java/com/kurkus/kusinsa/config/redis/RedisCacheConfig.java
@@ -1,0 +1,68 @@
+package com.kurkus.kusinsa.config.redis;
+
+
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+
+import static com.kurkus.kusinsa.utils.constants.RedisCacheConstants.*;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.cache.CacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisCacheConfig {
+
+    @Value("${spring.redis.cache.host}")
+    private String redisHost;
+
+    @Value("${spring.redis.cache.port}")
+    private int redisPort;
+
+    @Bean("redisCacheConnectionFactory")
+    public RedisConnectionFactory redisCacheConnectionFactory() {
+        return new LettuceConnectionFactory(new RedisStandaloneConfiguration(redisHost, redisPort));
+    }
+
+    @Bean
+    @ConditionalOnExpression("'${spring.cache.type}' != 'none'")
+    public CacheManager redisCacheManager(@Qualifier("redisCacheConnectionFactory")
+                                              RedisConnectionFactory redisConnectionFactory) {
+        return RedisCacheManager
+                .RedisCacheManagerBuilder
+                .fromConnectionFactory(redisConnectionFactory)
+                .cacheDefaults(defaultConfiguration())
+                .withInitialCacheConfigurations(customConfigurationMap())
+                .build();
+    }
+
+    private RedisCacheConfiguration defaultConfiguration() {
+        RedisCacheConfiguration redisCacheConfiguration = RedisCacheConfiguration.defaultCacheConfig()
+                .serializeValuesWith(RedisSerializationContext
+                        .SerializationPair
+                        .fromSerializer(new GenericJackson2JsonRedisSerializer()))
+                .entryTtl(DEFAULT_EXPIRE_TIME_MIN);
+        return redisCacheConfiguration;
+    }
+
+    private Map<String, RedisCacheConfiguration> customConfigurationMap() {
+        Map<String, RedisCacheConfiguration> configurationsMap = new HashMap<>();
+        configurationsMap.put(ORDER_RANK, defaultConfiguration().entryTtl(RANK_EXPIRE_TIME_MIN));
+        configurationsMap.put(CLICK_RANK, defaultConfiguration().entryTtl(RANK_EXPIRE_TIME_MIN));
+        return configurationsMap;
+    }
+
+
+}

--- a/src/main/java/com/kurkus/kusinsa/dao/RankDao.java
+++ b/src/main/java/com/kurkus/kusinsa/dao/RankDao.java
@@ -32,14 +32,19 @@ public class RankDao {
 
     // 애는 그냥 10개를 가지고오면됨
     public List<Long> orderRankTop10(){
-        Set<Object> set = redisSetTemplate.opsForZSet().reverseRangeByScore(ORDER_KEY, 5, 1000, 0, 10);
+        Set<Object> set = redisSetTemplate.opsForZSet().reverseRangeByScore("test2", 5, 1000, 0, 10);
         return set.stream().map(o -> new Long(o.toString())).collect(Collectors.toList());
     }
 
 //    // top10 리스트
     public List<Long> clickRankTop10(){
-        Set<Object> set = redisSetTemplate.opsForZSet().reverseRangeByScore(CLICK_KEY, 5, 3000, 0, 10);
+        Set<Object> set = redisSetTemplate.opsForZSet().reverseRangeByScore("test2", 5, 3000, 0, 10);
         return set.stream().map(o -> new Long(o.toString())).collect(Collectors.toList());
+    }
+
+    public void resetRankData(){
+        redisSetTemplate.delete(ORDER_KEY);
+        redisSetTemplate.delete(CLICK_KEY);
     }
 
 

--- a/src/main/java/com/kurkus/kusinsa/dao/RankDao.java
+++ b/src/main/java/com/kurkus/kusinsa/dao/RankDao.java
@@ -18,9 +18,6 @@ public class RankDao {
     private final RedisTemplate<String, Object> redisSetTemplate;
     private final String ORDER_KEY = "order_product"; // 가장많이 주문된 상품
     private final String CLICK_KEY = "click_product"; // 가장많이 조회된 상품
-    private final String BEFORE_CLICK_KEY = "before_click_product"; // 이전 랭킹 hash
-
-    private final ProductRepository productRepository;
 
     public void orderCount(Long productId) {
         redisSetTemplate.opsForZSet().incrementScore(ORDER_KEY, productId.toString(), 1);
@@ -30,26 +27,22 @@ public class RankDao {
         redisSetTemplate.opsForZSet().incrementScore(CLICK_KEY, productId.toString(), 1);
     }
 
-    // 애는 그냥 10개를 가지고오면됨
-    public List<Long> orderRankTop10(){
-        Set<Object> set = redisSetTemplate.opsForZSet().reverseRangeByScore("test2", 5, 1000, 0, 10);
+
+    public List<Long> orderRankTop10() {
+        Set<Object> set = redisSetTemplate.opsForZSet().reverseRangeByScore(ORDER_KEY, 10, 1000, 0, 10);
         return set.stream().map(o -> new Long(o.toString())).collect(Collectors.toList());
     }
 
-//    // top10 리스트
-    public List<Long> clickRankTop10(){
-        Set<Object> set = redisSetTemplate.opsForZSet().reverseRangeByScore("test2", 5, 3000, 0, 10);
+
+    public List<Long> clickRankTop10() {
+        Set<Object> set = redisSetTemplate.opsForZSet().reverseRangeByScore(CLICK_KEY, 20, 3000, 0, 10);
         return set.stream().map(o -> new Long(o.toString())).collect(Collectors.toList());
     }
 
-    public void resetRankData(){
+    public void resetRankData() {
         redisSetTemplate.delete(ORDER_KEY);
         redisSetTemplate.delete(CLICK_KEY);
     }
-
-
-
-
 
 
 }

--- a/src/main/java/com/kurkus/kusinsa/dto/response/rank/OrderRankResponse.java
+++ b/src/main/java/com/kurkus/kusinsa/dto/response/rank/OrderRankResponse.java
@@ -11,7 +11,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class OrderRankResponse {
 
-    private Long id;
+    private Long productId;
     private String name;
     private Long price;
     private String thumbnailImagePath;

--- a/src/main/java/com/kurkus/kusinsa/entity/documents/ClickRank.java
+++ b/src/main/java/com/kurkus/kusinsa/entity/documents/ClickRank.java
@@ -1,0 +1,2 @@
+package com.kurkus.kusinsa.entity.documents;public class ClickRank {
+}

--- a/src/main/java/com/kurkus/kusinsa/entity/documents/OrderRank.java
+++ b/src/main/java/com/kurkus/kusinsa/entity/documents/OrderRank.java
@@ -1,38 +1,33 @@
 package com.kurkus.kusinsa.entity.documents;
 
-
-import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
-
-import com.kurkus.kusinsa.dto.response.rank.ClickRankResponseV1;
-import lombok.AllArgsConstructor;
+import com.kurkus.kusinsa.dto.response.rank.OrderRankResponse;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.mapping.Document;
 
-@Document(collection = "click_ranks")
+@Document(collection = "order_ranks")
 @Getter
 @NoArgsConstructor
-public class ClickRank {
+public class OrderRank {
 
     @Id
     private String id;
     private Long productId;
     private String name;
+    private Long price;
     private int rank;
     private String createdAt;
 
-    public ClickRank(Long productId, String name, int rank, String createdAt){
+    public OrderRank(Long productId, String name, Long price, int rank, String createdAt) {
         this.productId = productId;
         this.name = name;
+        this.price = price;
         this.rank = rank;
         this.createdAt = createdAt;
     }
 
-
-    public static ClickRank of(ClickRankResponseV1 response, String createdAt){
-        return new ClickRank(response.getProductId(), response.getName(), response.getRank(), createdAt);
+    public static OrderRank of(OrderRankResponse response, String createdAt) {
+        return new OrderRank(response.getProductId(), response.getName(), response.getPrice(), response.getRank(), createdAt);
     }
-
 }

--- a/src/main/java/com/kurkus/kusinsa/repository/mongo/ClickRankRepository.java
+++ b/src/main/java/com/kurkus/kusinsa/repository/mongo/ClickRankRepository.java
@@ -1,0 +1,2 @@
+package com.kurkus.kusinsa.repository.mongo;public interface ClickRankRepository {
+}

--- a/src/main/java/com/kurkus/kusinsa/repository/mongo/ClickRankRepository.java
+++ b/src/main/java/com/kurkus/kusinsa/repository/mongo/ClickRankRepository.java
@@ -1,2 +1,8 @@
-package com.kurkus.kusinsa.repository.mongo;public interface ClickRankRepository {
+package com.kurkus.kusinsa.repository.mongo;
+
+import com.kurkus.kusinsa.entity.documents.ClickRank;
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+public interface ClickRankRepository extends MongoRepository<ClickRank, String> {
+
 }

--- a/src/main/java/com/kurkus/kusinsa/repository/mongo/OrderRankRepository.java
+++ b/src/main/java/com/kurkus/kusinsa/repository/mongo/OrderRankRepository.java
@@ -1,0 +1,7 @@
+package com.kurkus.kusinsa.repository.mongo;
+
+import com.kurkus.kusinsa.entity.documents.OrderRank;
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+public interface OrderRankRepository extends MongoRepository<OrderRank, String> {
+}

--- a/src/main/java/com/kurkus/kusinsa/scheduler/CronScheduler.java
+++ b/src/main/java/com/kurkus/kusinsa/scheduler/CronScheduler.java
@@ -1,2 +1,57 @@
-package com.kurkus.kusinsa.scheduler;public class CronScheduler {
+package com.kurkus.kusinsa.scheduler;
+
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import com.kurkus.kusinsa.dto.response.rank.ClickRankResponseV1;
+import com.kurkus.kusinsa.dto.response.rank.OrderRankResponse;
+import com.kurkus.kusinsa.entity.documents.ClickRank;
+import com.kurkus.kusinsa.entity.documents.OrderRank;
+import com.kurkus.kusinsa.repository.mongo.ClickRankRepository;
+import com.kurkus.kusinsa.repository.mongo.OrderRankRepository;
+import com.kurkus.kusinsa.service.RankService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class CronScheduler {
+
+
+    private final RankService rankService;
+    private final ClickRankRepository clickRankRepository;
+    private final OrderRankRepository orderRankRepository;
+
+    /**
+     * 1. sorted Set 캐시를 초기화 시킨다
+     * 2. 데이터를 mongoDB에 저장한다
+     * 3. 3시간 마다 그러면 캐시에 있는 데이터를 초기화시킨다 그리고 다시 호출한다
+     * 아니면 의도적으로 caceheivct를 3시간마다 호출시키기
+     */
+    @Scheduled(cron = "0 0/4 * * * *") // 초 분 시 일 월 요일
+    public void myMethod(){
+        log.info("스케줄러 시작");
+        //
+        // 캐시 초기화
+        //
+        String time = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH"));// 년 월 일 시
+        // click
+        List<ClickRank> saveClickList = rankService.clickRankTop10().stream()
+                .map(c -> ClickRank.of(c, time)).collect(Collectors.toList());
+        clickRankRepository.saveAll(saveClickList);
+        // order
+        List<OrderRank> saveOrderList = rankService.orderRankTop10().stream().
+                map(o -> OrderRank.of(o, time)).collect(Collectors.toList());
+        orderRankRepository.saveAll(saveOrderList);
+        log.info("스케줄러 끝");
+    }
+
+
 }

--- a/src/main/java/com/kurkus/kusinsa/scheduler/CronScheduler.java
+++ b/src/main/java/com/kurkus/kusinsa/scheduler/CronScheduler.java
@@ -17,6 +17,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 
 @Slf4j
@@ -33,14 +34,14 @@ public class CronScheduler {
      * 1. sorted Set 캐시를 초기화 시킨다
      * 2. 데이터를 mongoDB에 저장한다
      * 3. 3시간 마다 그러면 캐시에 있는 데이터를 초기화시킨다 그리고 다시 호출한다
-     * 아니면 의도적으로 caceheivct를 3시간마다 호출시키기
      */
-    @Scheduled(cron = "0 0/4 * * * *") // 초 분 시 일 월 요일
+//    @Scheduled(cron = "0 0 0/3 * * *")
+//    @Scheduled(cron = "0 0/5 * * * *") // 초 분 시 일 월 요일
     public void myMethod(){
         log.info("스케줄러 시작");
-        //
-        // 캐시 초기화
-        //
+        
+        rankService.resetRankData();
+
         String time = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH"));// 년 월 일 시
         // click
         List<ClickRank> saveClickList = rankService.clickRankTop10().stream()
@@ -50,6 +51,7 @@ public class CronScheduler {
         List<OrderRank> saveOrderList = rankService.orderRankTop10().stream().
                 map(o -> OrderRank.of(o, time)).collect(Collectors.toList());
         orderRankRepository.saveAll(saveOrderList);
+
         log.info("스케줄러 끝");
     }
 

--- a/src/main/java/com/kurkus/kusinsa/scheduler/CronScheduler.java
+++ b/src/main/java/com/kurkus/kusinsa/scheduler/CronScheduler.java
@@ -1,0 +1,2 @@
+package com.kurkus.kusinsa.scheduler;public class CronScheduler {
+}

--- a/src/main/java/com/kurkus/kusinsa/service/RankService.java
+++ b/src/main/java/com/kurkus/kusinsa/service/RankService.java
@@ -5,12 +5,16 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static com.kurkus.kusinsa.utils.constants.RedisCacheConstants.*;
+
 import com.kurkus.kusinsa.dao.RankDao;
 import com.kurkus.kusinsa.dto.response.rank.ClickRankResponseV1;
 import com.kurkus.kusinsa.dto.response.rank.OrderRankResponse;
 import com.kurkus.kusinsa.entity.Product;
 import com.kurkus.kusinsa.repository.ProductRepository;
+import com.kurkus.kusinsa.utils.constants.RedisCacheConstants;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 
 
@@ -21,6 +25,7 @@ public class RankService {
     private final RankDao rankDao;
     private final ProductRepository productRepository;
 
+    @Cacheable(value = ORDER_RANK)
     public List<OrderRankResponse> orderRankTop10() {
         List<Long> longs = rankDao.orderRankTop10();
         Map<Long, Integer> map = new HashMap<>();
@@ -37,6 +42,7 @@ public class RankService {
         return result;
     }
 
+    @Cacheable(value = CLICK_RANK)
     public List<ClickRankResponseV1> clickRankTop10(){
         List<Long> longs = rankDao.clickRankTop10();
         Map<Long, Integer> map = new HashMap<>();

--- a/src/main/java/com/kurkus/kusinsa/service/RankService.java
+++ b/src/main/java/com/kurkus/kusinsa/service/RankService.java
@@ -53,6 +53,11 @@ public class RankService {
         return result;
     }
 
+    public void resetRankData(){
+        rankDao.resetRankData();
+    }
+
+
 
 
 }

--- a/src/main/java/com/kurkus/kusinsa/service/RankService.java
+++ b/src/main/java/com/kurkus/kusinsa/service/RankService.java
@@ -14,12 +14,14 @@ import com.kurkus.kusinsa.entity.Product;
 import com.kurkus.kusinsa.repository.ProductRepository;
 import com.kurkus.kusinsa.utils.constants.RedisCacheConstants;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 
 
 @RequiredArgsConstructor
 @Service
+@Slf4j
 public class RankService {
 
     private final RankDao rankDao;

--- a/src/main/java/com/kurkus/kusinsa/utils/constants/RedisCacheConstants.java
+++ b/src/main/java/com/kurkus/kusinsa/utils/constants/RedisCacheConstants.java
@@ -1,0 +1,12 @@
+package com.kurkus.kusinsa.utils.constants;
+
+import java.time.Duration;
+
+public final class RedisCacheConstants {
+
+    public static final String ORDER_RANK = "ORDER_RANK";
+    public static final String CLICK_RANK = "CLICK_RANK";
+
+    public static final Duration DEFAULT_EXPIRE_TIME_MIN = Duration.ofMinutes(1L);
+    public static final Duration RANK_EXPIRE_TIME_MIN = Duration.ofMinutes(8L); // 5분
+}

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -4,6 +4,12 @@ spring.datasource.url=jdbc:mysql://localhost:3306/kusinsa?allowMultiQueries=true
 spring.datasource.username=root
 spring.datasource.password=1234
 
+## MongoDB
+spring.data.mongodb.host=localhost
+spring.data.mongodb.port=27017
+spring.data.mongodb.database=kusinsa
+
+
 # JPA
 spring.jpa.hibernate.ddl-auto=validate
 spring.jpa.generate-ddl=false

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -29,5 +29,9 @@ spring.session.store-type=redis
 spring.redis.set.host = localhost
 spring.redis.set.port = 6479
 
+# redis cache
+spring.redis.cache.host = localhost
+spring.redis.cache.port = 6579
+spring.cache.type=redis
 
 

--- a/src/test/java/com/kurkus/kusinsa/test.java
+++ b/src/test/java/com/kurkus/kusinsa/test.java
@@ -5,11 +5,14 @@ import java.util.*;
 
 import com.kurkus.kusinsa.dao.RankDao;
 import com.kurkus.kusinsa.dto.response.rank.OrderRankResponse;
+import com.kurkus.kusinsa.entity.documents.ClickRank;
+import com.kurkus.kusinsa.repository.mongo.ClickRankRepository;
 import com.kurkus.kusinsa.service.RankService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.transaction.annotation.Transactional;
 
 @SpringBootTest
 public class test {
@@ -22,17 +25,14 @@ public class test {
 
     @Autowired
     RankService rankService;
+
+    @Autowired
+    ClickRankRepository test;
     
     @Test
+    @Transactional
     public void before채우기(){
-        // 이전에 20등까지있는거임 // 구 버전 순위
-        List<OrderRankResponse> orderRankResponses = rankService.orderRankTop10();
-        for(OrderRankResponse o : orderRankResponses){
-            System.out.println("o.getName() = " + o.getName());
-            System.out.println("o.getId() = " + o.getId());
-            System.out.println("o.getRank() = " + o.getRank());
-        }
-
+        test.save(new ClickRank(22L, "test", 1, "hello"));
 
     }
 

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -38,3 +38,8 @@ spring.session.store-type=none
 # redis set
 spring.redis.set.host = localhost
 spring.redis.set.port = 6479
+
+# redis cache
+spring.redis.cache.host = localhost
+spring.redis.cache.port = 6579
+spring.cache.type=none

--- a/src/test/resources/docker-compose.yml
+++ b/src/test/resources/docker-compose.yml
@@ -6,3 +6,13 @@ services:
     container_name: redisTest-session
     ports:
       - 6379:6379
+  redis-set:
+    image: redis
+    container_name: redisTest-set
+    ports:
+      - 6479:6379
+  redis-cache:
+    image: redis
+    container_name: redisTest-cache
+    ports:
+      - 6579:6379


### PR DESCRIPTION
### OverView
Ranking에 대한 스케줄러를 개발하였습니다.
3시간마다 판매, 클릭 Top10에 대한 정보를 MongoDB에 저장하고 초기화 시킵니다.
초기화시 정보를 보여줄때 판매갯수가 적기때문에 1시간동안 이전시간의 정보를 사용합니다.
1시간동안 데이터가 쌓이면 보여줄수있도록 캐시 TTL 4시간으로 정했습니다.